### PR TITLE
[REFACTOR] Auth 로그인 시, email -> 카카오 고유 ID로 변경, isRegisted 필드 추가

### DIFF
--- a/src/main/java/depth/main_project/PayKids_Server/domain/auth/AuthController.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/auth/AuthController.java
@@ -43,8 +43,7 @@ public class AuthController {
         if (!tokenService.expiredToken(refreshToken)) {
             throw new MapperException(ErrorCode.TOKEN_EXPIRED_ERROR);
         }
-
         String newAccessToken = tokenService.generateAccessToken(UserUUID);
-        return ApiResult.ok(new LoginResponse(newAccessToken, refreshToken));
+        return ApiResult.ok(new LoginResponse(newAccessToken, refreshToken, "Bearer", true));
     }
 }

--- a/src/main/java/depth/main_project/PayKids_Server/domain/auth/AuthService.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/auth/AuthService.java
@@ -35,8 +35,9 @@ public class AuthService {
         String accessToken = tokenService.generateAccessToken(user.getUuid());
         String refreshToken = tokenService.generateRefreshToken(user.getUuid());
 
-        // 4. Access Token, Refresh Token 반환
-        return new LoginResponse(accessToken, refreshToken);
+        boolean isRegistered = user.getNickname() != null;
+
+        return new LoginResponse( accessToken, refreshToken, "Bearer", isRegistered );
     }
 
     private User registerNewUser(UserDTO userDTO) {

--- a/src/main/java/depth/main_project/PayKids_Server/domain/auth/AuthService.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/auth/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
         UserDTO userDTO = kakaoTokenValidator.validateAndExtract(idToken);
 
         // 2. 사용자 존재 여부 확인
-        User user = userRepository.findByEmail(userDTO.getEmail())
+        User user = userRepository.findByKakaoId(userDTO.getSub())
                 .orElseGet(() -> registerNewUser(userDTO)); // 존재하지 않으면 회원가입
 
         // 3. Access Token 및 Refresh Token 생성
@@ -46,6 +46,7 @@ public class AuthService {
         }
 
         User newUser = User.builder()
+                .kakaoId(userDTO.getSub())
                 .email(userDTO.getEmail())
                 .username(userDTO.getNickname())
                 .profileImageURL(profileImageURL)

--- a/src/main/java/depth/main_project/PayKids_Server/domain/auth/KakaoTokenValidator.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/auth/KakaoTokenValidator.java
@@ -39,11 +39,12 @@ public class KakaoTokenValidator {
             JWTVerifier verifier = JWT.require(algorithm).build();
             verifier.verify(idToken);
 
+            String sub = decodedJWT.getClaim("sub").asString();
             String nickname = decodedJWT.getClaim("nickname").asString();
             String email = decodedJWT.getClaim("email").asString();
             String profileImageURL = decodedJWT.getClaim("profile_image").asString();
 
-            return new UserDTO(nickname, email, profileImageURL);
+            return new UserDTO(sub, nickname, email, profileImageURL);
         } catch (Exception e) {
             throw new MapperException(ErrorCode.TOKEN_INVALID);
         }

--- a/src/main/java/depth/main_project/PayKids_Server/domain/auth/LoginResponse.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/auth/LoginResponse.java
@@ -8,4 +8,6 @@ import lombok.Data;
 public class LoginResponse {
     private String accessToken;
     private String refreshToken;
+    private String tokenType;
+    private Boolean isRegistered;
 }

--- a/src/main/java/depth/main_project/PayKids_Server/domain/user/UserService.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/user/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
         User user = userRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MapperException(ErrorCode.USER_NOT_FOUND));
 
-        return new UserDTO(user.getId(), user.getUsername(), user.getUuid(), user.getNickname(), user.getEmail(), user.getProfileImageURL(), user.getStageStatus());
+        return new UserDTO(user.getId(), user.getKakaoId(), user.getUsername(), user.getUuid(), user.getNickname(), user.getEmail(), user.getProfileImageURL(), user.getStageStatus());
     }
 
     public String saveNickname(String uuid, String nickname) {

--- a/src/main/java/depth/main_project/PayKids_Server/domain/user/dto/UserDTO.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/user/dto/UserDTO.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 public class UserDTO {
     private Long id;
+    private String sub;
     private String username;
     private String uuid;
     private String nickname;
@@ -16,7 +17,8 @@ public class UserDTO {
     private String profileImageURL;
     private Integer stageStatus;
 
-    public UserDTO(String nickname, String email, String profileImageURL) {
+    public UserDTO(String sub, String nickname, String email, String profileImageURL) {
+        this.sub = sub;
         this.nickname = nickname;
         this.email = email;
         this.profileImageURL = profileImageURL;

--- a/src/main/java/depth/main_project/PayKids_Server/domain/user/entity/User.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/user/entity/User.java
@@ -18,6 +18,9 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String kakaoId;
     private String username;
 
     @Column(nullable = false, unique = true, updatable = false)
@@ -34,7 +37,8 @@ public class User {
     private Integer stageStatus = 1;
 
     @Builder
-    public User(String username, String nickname, String email, String profileImageURL) {
+    public User(String kakaoId,  String username, String nickname, String email, String profileImageURL) {
+        this.kakaoId = kakaoId;
         this.username = username;
         this.nickname = nickname;
         this.email = email;

--- a/src/main/java/depth/main_project/PayKids_Server/domain/user/repository/UserRepository.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/user/repository/UserRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByKakaoId(String kakaoId);
     Optional<User> findByUuid(String uuid);
     boolean existsByNickname(String nickname);
 }


### PR DESCRIPTION
## 🧑‍💻 작업내용
1. 사용자가 로그인할때,  DB에 사용자가 있는지 찾는 과정에서 기준을 email에서 카카오계정고유아이디(kakaoId(sub))로 변경하였습니다.
- kakaoId(sub)은 카카오에서 부여한 사용자 식별값으로 email이 변경되어도 sub값은 변경되지 않는다네요. 
- email은 사용자가 카카오안에서 바꿀 수 있습니다. 
- 하하 이럴거면 UUID말고 kakaoId(sub)으로 할 걸 그랬습니다.

2. 닉네임 설정 화면 구분 처리를 위해 isRegistered 필드 추가하였습니다.

<br>

## 🌱 To Reviewers
<!-- PR을 검토할 때 확인해야 할 사항이 있나요? -->

<br>

## 💫 Issue Number
<!-- 이슈 번호를 작성해주세요 -->

<br>

## 💡 Reference
<!-- 참고한 자료, 읽기 좋은 글이 있다면 링크를 달아주세요! -->
