### PR TITLE
[FEAT] GPT 모델 변경 및 일일 채팅 횟수 제한 기능 추가

### DIFF
--- a/src/main/java/depth/main_project/PayKids_Server/PayKidsServerApplication.java
+++ b/src/main/java/depth/main_project/PayKids_Server/PayKidsServerApplication.java
@@ -2,7 +2,9 @@ package depth.main_project.PayKids_Server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class PayKidsServerApplication {
 

--- a/src/main/java/depth/main_project/PayKids_Server/domain/chatting/GPTController.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/chatting/GPTController.java
@@ -3,6 +3,7 @@ package depth.main_project.PayKids_Server.domain.chatting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -16,17 +17,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/gpt")
 public class GPTController {
-
-    @Value("${gpt.model}")
-    private String model;
-
-    @Value("${gpt.api.url}")
-    private String apiURL;
-
-    @Autowired
-    private RestTemplate template;
+    private final GPTService gptService;
 
     @Operation(summary = "채팅", description = "주어진 입력에 대한 대답을 합니다.")
     @ApiResponses(value = {
@@ -35,14 +29,19 @@ public class GPTController {
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
     @GetMapping("/chat")
-    public ResponseEntity<Map<String, String>> chat(@RequestParam(name = "prompt")String prompt) {
-        GPTRequestDTO requestDTO = new GPTRequestDTO(model, prompt);
-        GPTResponseDTO responseDTO = template.postForObject(apiURL, requestDTO, GPTResponseDTO.class);
-        String content = responseDTO.getChoices().get(0).getMessage().getContent();
+    public ResponseEntity<Map<String, String>> chat(@RequestParam String prompt, @RequestParam String token) {
 
-        Map<String, String> jsonResponse = new HashMap<>();
-        jsonResponse.put("response", content);
+        return ResponseEntity.ok(gptService.getChatting(prompt, token));
+    }
 
-        return ResponseEntity.ok(jsonResponse);
+    @Operation(summary = "남은 채팅 횟수 조회", description = "남은 채팅 횟수를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 대답함"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/number")
+    public ResponseEntity<Integer> getGPTNumber(@RequestParam String token) {
+        return ResponseEntity.ok(gptService.getGPTNumber(token));
     }
 }

--- a/src/main/java/depth/main_project/PayKids_Server/domain/chatting/GPTRequestDTO.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/chatting/GPTRequestDTO.java
@@ -13,7 +13,7 @@ public class GPTRequestDTO {
     public GPTRequestDTO(String model, String prompt) {
         this.model = model;
         this.messages =  new ArrayList<>();
-        String modifiedPrompt = "다음 질문에 대해 초등학교 저학년이 이해하기 쉽게 답변해주세요:\n" + prompt;
+        String modifiedPrompt = "다음 질문에 대해 초등학교 저학년이 이해하기 쉽게 답변해주세요, 만약 금융과 관련된 질문이 아니면 답을 하지 말아주세요: \n" + prompt;
         this.messages.add(new MessageDTO("user", modifiedPrompt));
     }
 }

--- a/src/main/java/depth/main_project/PayKids_Server/domain/chatting/GPTService.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/chatting/GPTService.java
@@ -1,0 +1,89 @@
+package depth.main_project.PayKids_Server.domain.chatting;
+
+import depth.main_project.PayKids_Server.domain.auth.TokenService;
+import depth.main_project.PayKids_Server.domain.user.entity.User;
+import depth.main_project.PayKids_Server.domain.user.repository.UserRepository;
+import depth.main_project.PayKids_Server.global.exception.ErrorCode;
+import depth.main_project.PayKids_Server.global.exception.MapperException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GPTService {
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
+
+    @Value("ft:gpt-4o-mini-2024-07-18:personal::AmIGcMts")
+    private String model;
+
+    @Value("${gpt.api.url}")
+    private String apiURL;
+
+    @Autowired
+    private RestTemplate template;
+
+    public Map<String, String> getChatting(String prompt, String token){
+        String uuId = tokenService.getUserUuidFromToken(token);
+
+        if (uuId == null) {
+            throw new MapperException(ErrorCode.TOKEN_ERROR);
+        }
+
+        User user = userRepository.findByUuid(uuId)
+                .orElseThrow(() -> new MapperException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getGptNumber() >= 10){
+            throw new MapperException(ErrorCode.GPT_ERROR);
+        } else {
+            user.setGptNumber(user.getGptNumber() + 1);
+            userRepository.save(user);
+        }
+
+        GPTRequestDTO requestDTO = new GPTRequestDTO(model, prompt);
+        GPTResponseDTO responseDTO = template.postForObject(apiURL, requestDTO, GPTResponseDTO.class);
+        String content = responseDTO.getChoices().get(0).getMessage().getContent();
+
+        Map<String, String> jsonResponse = new HashMap<>();
+        jsonResponse.put("response", content);
+
+        return jsonResponse;
+    }
+
+    public int getGPTNumber(String token){
+        String uuId = tokenService.getUserUuidFromToken(token);
+
+        if (uuId == null) {
+            throw new MapperException(ErrorCode.TOKEN_ERROR);
+        }
+
+        User user = userRepository.findByUuid(uuId)
+                .orElseThrow(() -> new MapperException(ErrorCode.USER_NOT_FOUND));
+
+        return (10 - user.getGptNumber());
+    }
+
+    @Scheduled(cron = "0 0 8 * * ?", zone = "Asia/Seoul")
+    public void resetGPTNumber() {
+        try {
+            List<User> users = userRepository.findAll();
+
+            for (User user : users) {
+                user.setGptNumber(0);
+                userRepository.save(user);
+            }
+        } catch (Exception e) {
+            throw new MapperException(ErrorCode.GPT_RESET_ERROR);
+        }
+    }
+}

--- a/src/main/java/depth/main_project/PayKids_Server/domain/user/entity/User.java
+++ b/src/main/java/depth/main_project/PayKids_Server/domain/user/entity/User.java
@@ -22,6 +22,7 @@ public class User {
     @Column(nullable = false, unique = true)
     private String kakaoId;
     private String username;
+    private int gptNumber = 0;
 
     @Column(nullable = false, unique = true, updatable = false)
     private String uuid = UUID.randomUUID().toString(); // UUID 자동 생성

--- a/src/main/java/depth/main_project/PayKids_Server/global/exception/ErrorCode.java
+++ b/src/main/java/depth/main_project/PayKids_Server/global/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "Nickname의 글자수는 최대 8글자"),
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "Nickname is invalid(닉네임이 공백인 경우)"),
     QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "Quiz not found"),
+    GPT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "하루 최대 이용량 초과 되었습니다"),
+    GPT_RESET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "유저 사용량 초기화 중 에러 발생"),
     TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 해석 문제가 발생했습니다"),
     TOKEN_EXPIRED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 유효기간이 만료되었습니다");
 


### PR DESCRIPTION
## 🧑‍💻 작업내용
<!-- 어떤 내용의 PR인가요? -->
퀴즈 데이터를 학습시킨 gpt 모델로 변경 했습니다.
User에 칼럼을 추가하고 일일 채팅 제한을 두었습니다.
해당 칼럼은 모든 유저가 새벽 1시에 0으로 초기화 됩니다.
<br>

## 🌱 To Reviewers
<!-- PR을 검토할 때 확인해야 할 사항이 있나요? -->
- User 엔티티 구조 변경
- 스케쥴 함수 추가로 인한 main 함수 어노테이션 추가
<br>

## 💫 Issue Number
<!-- 이슈 번호를 작성해주세요 -->

<br>

## 💡 Reference
<!-- 참고한 자료, 읽기 좋은 글이 있다면 링크를 달아주세요! -->
